### PR TITLE
General fixes

### DIFF
--- a/src/main/java/com/Jacksonnn/DCEvents/Commands/SubCommands/Info.java
+++ b/src/main/java/com/Jacksonnn/DCEvents/Commands/SubCommands/Info.java
@@ -73,7 +73,7 @@ public class Info implements EventSubCommand {
         }
 
         sender.sendMessage(GeneralMethods.getEventsPrefix() + "Information for the " + ChatColor.BOLD + event.getEventName() + ChatColor.YELLOW + " event:");
-        sender.sendMessage(ChatColor.GRAY + "Event Name: " + ChatColor.GREEN + event.getEventName() + ChatColor.GRAY + " | EventHost: " + ChatColor.GREEN + event.getEventStaff());
+        sender.sendMessage(ChatColor.GRAY + "Event Name: " + ChatColor.GREEN + event.getEventName() + ChatColor.GRAY + " | EventHost: " + ChatColor.GREEN + event.getEventStaff().getName());
         sender.sendMessage(ChatColor.GRAY + "Event Type: " + ChatColor.GREEN + eventType + ChatColor.GRAY + " | Players (" + ChatColor.GREEN + event.getEventPlayers().size() + ChatColor.GRAY + "):");
 
         String eventPlayers = ChatColor.GREEN + " ";

--- a/src/main/java/com/Jacksonnn/DCEvents/Commands/SubCommands/List.java
+++ b/src/main/java/com/Jacksonnn/DCEvents/Commands/SubCommands/List.java
@@ -46,7 +46,7 @@ public class List implements EventSubCommand {
         sender.sendMessage(GeneralMethods.getEventsPrefix() + "List of Events:");
 
         for (Event event : GeneralMethods.getEvents()) {
-            sender.sendMessage(ChatColor.GRAY + event.getEventName() + " (" + event.getEventPlayers().size() + ") - " + ChatColor.GREEN + event.getEventStaff());
+            sender.sendMessage(ChatColor.GRAY + event.getEventName() + " (" + event.getEventPlayers().size() + ") - " + ChatColor.GREEN + event.getEventStaff().getName());
         }
 
     }

--- a/src/main/java/com/Jacksonnn/DCEvents/Commands/SubCommands/Start.java
+++ b/src/main/java/com/Jacksonnn/DCEvents/Commands/SubCommands/Start.java
@@ -64,9 +64,9 @@ public class Start implements EventSubCommand {
                     }
                 }
                 Event event = new Event(args.get(0), player, ((Player) sender).getLocation());
-                sender.sendMessage(GeneralMethods.getEventsPrefix() + "Successfully created event, " + event.getEventName() + ", by, " + event.getEventStaff());
+                sender.sendMessage(GeneralMethods.getEventsPrefix() + "Successfully created event, " + event.getEventName() + ", by, " + event.getEventStaff().getName());
                 sender.sendMessage(" ");
-                Bukkit.broadcastMessage(GeneralMethods.getEventsPrefix() + "Now starting event, " + event.getEventName() + ", hosted by, " + event.getEventStaff() + ". -Console");
+                Bukkit.broadcastMessage(GeneralMethods.getEventsPrefix() + "Now starting event, " + event.getEventName() + ", hosted by, " + event.getEventStaff().getName() + ". -Console");
             } else {
                 sender.sendMessage(GeneralMethods.getEventsPrefix() + "Error! You must be a player to execute this command.");
             }

--- a/src/main/java/com/Jacksonnn/DCEvents/Event.java
+++ b/src/main/java/com/Jacksonnn/DCEvents/Event.java
@@ -61,7 +61,7 @@ public class Event {
         EventPlayer player = new EventPlayer(eventPlayers.size() + 1, Bukkit.getPlayer(name));
         eventPlayers.add(player);
         sender.sendMessage(GeneralMethods.getEventsPrefix() + name + " has joined the event, " + this.getEventName() + ".");
-        player.getPlayer().sendMessage(GeneralMethods.getEventsPrefix() + "You have been signed up for the " + getEventName() + " event hosted by " + getEventStaff() + ".");
+        player.getPlayer().sendMessage(GeneralMethods.getEventsPrefix() + "You have been signed up for the " + getEventName() + " event hosted by " + getEventStaff().getName() + ".");
     }
 
     public void addPlayer(CommandSender sender, EventPlayer player) {
@@ -69,7 +69,7 @@ public class Event {
             sender.sendMessage(GeneralMethods.getEventsPrefix() + "Player" + player.getName() + " has already joined the event!");
         } else {
             eventPlayers.add(player);
-            player.getPlayer().sendMessage(GeneralMethods.getEventsPrefix() + "You have been signed up for the " + getEventName() + " event hosted by " + getEventStaff() + ".");
+            player.getPlayer().sendMessage(GeneralMethods.getEventsPrefix() + "You have been signed up for the " + getEventName() + " event hosted by " + getEventStaff().getName() + ".");
         }
     }
 

--- a/src/main/java/com/Jacksonnn/DCEvents/Games/BlockParty/BlockPartyRunnable.java
+++ b/src/main/java/com/Jacksonnn/DCEvents/Games/BlockParty/BlockPartyRunnable.java
@@ -104,7 +104,7 @@ public class BlockPartyRunnable extends BukkitRunnable {
         blockParty.remove();
     }
     private void declareWinners(ArrayList<Player> players) {
-        StringBuilder message = new StringBuilder(GeneralMethods.getEventsPrefix()).append("Congratulations to ");
+        StringBuilder message = new StringBuilder("Congratulations to ");
         for (int i = 0; i < players.size(); i++) {
             Player player = players.get(i);
             if (i == 0)
@@ -130,7 +130,7 @@ public class BlockPartyRunnable extends BukkitRunnable {
     private void playSound() {
         float pitch = random.nextFloat() * 1.5f + 0.5f;
         for (Player player : alivePlayers)
-            player.playSound(player.getEyeLocation(), Sound.BLOCK_NOTE_BLOCK_PLING, SoundCategory.VOICE, 0.7f, pitch);
+            player.playSound(player.getEyeLocation(), Sound.BLOCK_NOTE_BLOCK_PLING, SoundCategory.VOICE, 0.4f, pitch);
     }
     private void shuffle() {
 //        float amountToShuffle = (float)blocks.length/LENGTH_OF_SHUFFLE;


### PR DESCRIPTION
Fixed player name text
Dampened Block Party shuffle sound effect

ToDo:
Diamond Luck
Permission node to allow players to /dce join [event name]
Add bossbar/countdown to Diamond Luck
Make countdown subcommand only display to players in the host's event
Consider limiting a host to one event?