### PR TITLE
Updated BlockParty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /DCEvents.iml
 /.idea/
 /target/
-/.gitignore

--- a/src/main/java/com/Jacksonnn/DCEvents/Commands/SubCommands/Start.java
+++ b/src/main/java/com/Jacksonnn/DCEvents/Commands/SubCommands/Start.java
@@ -104,9 +104,9 @@ public class Start implements EventSubCommand {
                     sender.sendMessage(GeneralMethods.getEventsPrefix() + "Error! " + eventType + " is not an event type.");
                     return;
             }
-            sender.sendMessage(GeneralMethods.getEventsPrefix() + "Successfully created event, " + name + ", by, " + staff);
+            sender.sendMessage(GeneralMethods.getEventsPrefix() + "Successfully created event, " + name + ", by, " + staff.getName());
             sender.sendMessage(" ");
-            Bukkit.broadcastMessage(GeneralMethods.getEventsPrefix() + "Now starting event, " + name + ", hosted by, " + staff + ". -Console");
+            Bukkit.broadcastMessage(GeneralMethods.getEventsPrefix() + "Now starting event, " + name + ", hosted by, " + staff.getName() + ". -Console");
         } else {
             sender.sendMessage(GeneralMethods.getEventsPrefix() + "Error! " + getProperUse());
         }

--- a/src/main/java/com/Jacksonnn/DCEvents/DCEvents.java
+++ b/src/main/java/com/Jacksonnn/DCEvents/DCEvents.java
@@ -44,6 +44,7 @@ public final class DCEvents extends JavaPlugin {
     public void onDisable() {
         // Plugin shutdown logic
         Bukkit.getServer().getLogger().info(ChatColor.DARK_AQUA + "DCEvents has been disabled.");
+        GeneralMethods.removeAllEvents();
     }
 
     public static DCEvents getDCEvents() {

--- a/src/main/java/com/Jacksonnn/DCEvents/Games/BlockParty/BlockParty.java
+++ b/src/main/java/com/Jacksonnn/DCEvents/Games/BlockParty/BlockParty.java
@@ -54,7 +54,7 @@ public class BlockParty extends Event {
 
     @Override public void remove() {
         super.remove();
-        if (!runnable.isCancelled())
+        if (isRunning)
             runnable.cancel();
     }
 }

--- a/src/main/java/com/Jacksonnn/DCEvents/Games/BlockParty/BlockPartyRunnable.java
+++ b/src/main/java/com/Jacksonnn/DCEvents/Games/BlockParty/BlockPartyRunnable.java
@@ -4,16 +4,24 @@ import com.Jacksonnn.DCEvents.EventPlayer.EventPlayer;
 import com.Jacksonnn.DCEvents.GeneralMethods;
 import org.bukkit.*;
 import org.bukkit.block.Block;
+import org.bukkit.boss.BarColor;
+import org.bukkit.boss.BarStyle;
+import org.bukkit.boss.BossBar;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Random;
 
 public class BlockPartyRunnable extends BukkitRunnable {
 
+    private static final Material[] glass = new Material[] {Material.WHITE_STAINED_GLASS, Material.BLACK_STAINED_GLASS,
+            Material.BLUE_STAINED_GLASS, Material.BROWN_STAINED_GLASS, Material.CYAN_STAINED_GLASS, Material.GRAY_STAINED_GLASS, Material.GREEN_STAINED_GLASS,
+            Material.LIGHT_BLUE_STAINED_GLASS, Material.LIGHT_GRAY_STAINED_GLASS, Material.LIME_STAINED_GLASS, Material.MAGENTA_STAINED_GLASS,
+            Material.ORANGE_STAINED_GLASS, Material.PINK_STAINED_GLASS, Material.PURPLE_STAINED_GLASS, Material.RED_STAINED_GLASS, Material.YELLOW_STAINED_GLASS};
     private static final Material[] wool = new Material[] {Material.WHITE_CONCRETE, Material.BLACK_CONCRETE,
             Material.BLUE_CONCRETE, Material.BROWN_CONCRETE, Material.CYAN_CONCRETE, Material.GRAY_CONCRETE, Material.GREEN_CONCRETE,
             Material.LIGHT_BLUE_CONCRETE, Material.LIGHT_GRAY_CONCRETE, Material.LIME_CONCRETE, Material.MAGENTA_CONCRETE,
@@ -36,16 +44,19 @@ public class BlockPartyRunnable extends BukkitRunnable {
     private Block[] blocks;
     private int y;
 
-    private int stage = 0;
-    private int frame = 1;
 
     private int soundFrequency = 2; // while shuffling, every X ticks, make a sound
-    private int timeAllottedToBeProper = 50; // how much time players have to stand on the right color before they die
+    private int timeAllottedToBeProper = 52; // how much time players have to stand on the right color before they die
     private int timeBetweenDeathAndShuffle = 60;
+    private int timeToGetReady = 100;
 
+    private int stage = -1;
+    private int frame = timeToGetReady;
     private int colorsUsed = 0;
     private int[] colors = new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
     private int currentColor = 0;
+    private ChatColor curChatColor = null;
+    private BossBar bossBar;
 
     public BlockPartyRunnable(BlockParty blockParty) {
         random = new Random();
@@ -56,6 +67,17 @@ public class BlockPartyRunnable extends BukkitRunnable {
 
     @Override public void run() {
         switch (stage) {
+            case -1: // get ready!
+                if (--frame <= 0)
+                    stage = 1;
+                display((double)frame/timeToGetReady);
+                break;
+            case 0: // wait, countdown to shuffle
+                if (--frame == timeBetweenDeathAndShuffle-20)
+                    killFallingPlayers();
+                else if (frame <= 0)
+                    stage++;
+                break;
             case 1: // check if winner, shuffle, display color
                 if (frame == 0) {
                     if (checkIfWinner())
@@ -64,26 +86,32 @@ public class BlockPartyRunnable extends BukkitRunnable {
                         addColor();
                     if (colorsUsed < 15)
                         addColor();
+                    display(ChatColor.AQUA + "Shuffling!");
                 }
                 if (frame % soundFrequency == 0)
                     playSound();
                 shuffle();
                 if (++frame == LENGTH_OF_SHUFFLE) {
+                    timeAllottedToBeProper = Math.max(timeAllottedToBeProper - 2, 0);
                     frame = timeAllottedToBeProper;
-                    displayColor();
+                    randomizeColor();
                     stage++;
-                    timeAllottedToBeProper -= 2;
+                    display(curChatColor + woolNames[currentColor] + "!", 1);
+                    displayColor();
+                } else {
+                    display((double)frame/LENGTH_OF_SHUFFLE);
                 }
                 break;
-            case 3: // kill improper players
-                killImproperPlayers();
-                frame = timeBetweenDeathAndShuffle;
-                stage = 0;
-                break;
-            case 0: // wait
-            case 2: // wait
+            case 2: // wait, countdown to death
                 if (--frame <= 0)
                     stage++;
+                display((double)frame/timeAllottedToBeProper);
+                break;
+            case 3: // kill improper players
+//                killImproperPlayers();
+                removeWrongColorBlocks();
+                frame = timeBetweenDeathAndShuffle;
+                stage = 0;
                 break;
         }
     }
@@ -129,7 +157,7 @@ public class BlockPartyRunnable extends BukkitRunnable {
     }
     private void playSound() {
         float pitch = random.nextFloat() * 1.5f + 0.5f;
-        for (Player player : alivePlayers)
+        for (Player player : bossBar.getPlayers())
             player.playSound(player.getEyeLocation(), Sound.BLOCK_NOTE_BLOCK_PLING, SoundCategory.VOICE, 0.4f, pitch);
     }
     private void shuffle() {
@@ -143,18 +171,58 @@ public class BlockPartyRunnable extends BukkitRunnable {
     private void randomizeBlock(Block block) {
         block.setType(wool[colors[random.nextInt(colorsUsed)]]);
     }
-    private void displayColor() {
+    private void randomizeColor() {
         currentColor = colors[random.nextInt(colorsUsed)];
-        ChatColor chatColor;
         if (random.nextFloat() <= CHANCE_TO_MISCOLOR_TEXT)
-            chatColor = chatColors[random.nextInt(16)];
+            curChatColor = chatColors[random.nextInt(16)];
         else
-            chatColor = chatColors[currentColor];
-        for (Player player : alivePlayers) {
-            player.sendTitle("", chatColor + woolNames[currentColor] + "!", 0, frame, 0);
-        }
+            curChatColor = chatColors[currentColor];
     }
-    private void killImproperPlayers() {
+    private void displayColor() {
+        for (Player player : bossBar.getPlayers())
+            player.sendTitle("", bossBar.getTitle(), 0, timeAllottedToBeProper-2, 2);
+    }
+    private void display(String text, double percent) {
+        display(text);
+        display(percent);
+    }
+    private void display(String text) {
+        bossBar.setTitle(text);
+    }
+    private void display(double percent) {
+        bossBar.setProgress(percent);
+    }
+    private void removeWrongColorBlocks() {
+        Material safe = wool[currentColor];
+        for (Block block : blocks)
+            if (block.getType() != safe)
+                block.setType(Material.AIR);
+    }
+    private void killFallingPlayers() {
+        winners = (ArrayList<Player>)alivePlayers.clone();
+        for (int i = 0; i < alivePlayers.size(); i++) {
+            Player alivePlayer = alivePlayers.get(i);
+            if (!alivePlayer.isOnline()) {
+                alivePlayers.remove(i--);
+                continue;
+            }
+            if (alivePlayer.getLocation().getBlockY() < y) {
+                alivePlayer.setHealth(0);
+                alivePlayers.remove(i--);
+            }
+        }
+
+        for (Player player : bossBar.getPlayers()) {
+            if (blockParty.getEventStaff() != player && !alivePlayers.contains(player))
+                bossBar.removePlayer(player);
+        }
+
+        Material safe = glass[currentColor];
+        for (Block block : blocks)
+            if (block.getType() == Material.AIR)
+                block.setType(safe);
+    }
+    @Deprecated private void killImproperPlayers() {
         winners = (ArrayList<Player>)alivePlayers.clone();
         Material safeWool = wool[currentColor];
         for (int i = 0; i < alivePlayers.size(); i++) {
@@ -170,8 +238,18 @@ public class BlockPartyRunnable extends BukkitRunnable {
                 alivePlayers.remove(i--);
             }
         }
+
+        for (Player player : bossBar.getPlayers()) {
+            if (!alivePlayers.contains(player))
+                bossBar.removePlayer(player);
+        }
     }
 
+    @Override public void cancel() {
+        super.cancel();
+        if (bossBar != null)
+            bossBar.removeAll();
+    }
     public void setCorners(Location corner1, Location corner2) {
         y = corner1.getBlockY();
         World world = corner1.getWorld();
@@ -196,6 +274,10 @@ public class BlockPartyRunnable extends BukkitRunnable {
             blockParty.remove();
             return;
         }
+
+        bossBar = Bukkit.createBossBar(ChatColor.AQUA + "Get ready!", BarColor.BLUE, BarStyle.SOLID);
+        bossBar.setProgress(1);
+
         blocks = new Block[size];
         int i = 0;
         for (int x = startX; x <= endX; x++) {
@@ -204,8 +286,13 @@ public class BlockPartyRunnable extends BukkitRunnable {
             }
         }
 
-        for (EventPlayer player : blockParty.getEventPlayers())
-            if (player.getPlayer().isOnline())
+        for (EventPlayer player : blockParty.getEventPlayers()) {
+            if (player.getPlayer().isOnline()) {
                 alivePlayers.add(player.getPlayer());
+                bossBar.addPlayer(player.getPlayer());
+            }
+        }
+        if (!bossBar.getPlayers().contains(blockParty.getEventStaff()))
+            bossBar.addPlayer(blockParty.getEventStaff());
     }
 }

--- a/src/main/java/com/Jacksonnn/DCEvents/GeneralMethods.java
+++ b/src/main/java/com/Jacksonnn/DCEvents/GeneralMethods.java
@@ -31,6 +31,13 @@ public class GeneralMethods {
         events.remove(e);
     }
 
+    public static void removeAllEvents() {
+        int sentinel = 500;
+        int i = 0;
+        while (!events.isEmpty() && i++ != sentinel)
+            events.get(0).remove();
+    }
+
     public static boolean isTournament(Event e) {
         if (e instanceof Tournament) {
             return true;


### PR DESCRIPTION
Updated .gitignore to not include .gitignore (it automatically omits it anyways, but for the sake of professionality).
Fixed Start subcommand to not display the host's name as CraftPlayer(Name=~~~). Not sure how that snuck in there. There might still be a few stragglers here and there.
When the plugin is unloaded, all the events are removed.
Fixed BlockParty giving an error when attempting to end it before the runnable started.
BlockParty now removes blocks to allow players to fall instead of killing them directly.
BlockParty displays the current color in the subtitle, and also the bossbar.
BlockParty now fully utilizes the bossbar to display time remaining and current color.
BlockParty now displays subtitle/bossbar/sounds to event host even if they're not playing.